### PR TITLE
Handle optional wandb/pointops dependencies for simple PTv3

### DIFF
--- a/pointcept/models/__init__.py
+++ b/pointcept/models/__init__.py
@@ -1,27 +1,85 @@
+"""Model registry exports with optional dependency handling."""
+
+from __future__ import annotations
+
+import warnings
+from importlib import import_module
+
 from .builder import build_model
-from .default import DefaultSegmentor, DefaultClassifier
-from .modules import PointModule, PointModel
+from .default import DefaultClassifier, DefaultSegmentor
+from .modules import PointModel, PointModule
 
-# Backbones
-from .sparse_unet import *
-from .point_transformer import *
-from .point_transformer_v2 import *
-from .point_transformer_v3 import *
-from .stratified_transformer import *
-from .spvcnn import *
-from .octformer import *
-from .oacnns import *
+__all__ = [
+    "build_model",
+    "DefaultClassifier",
+    "DefaultSegmentor",
+    "PointModel",
+    "PointModule",
+]
 
-# from .swin3d import *
+_EXPORTED = set(__all__)
+_OPTIONAL_DEPENDENCIES = {
+    "wandb",
+    "pointops",
+    "pointops._C",
+    "pointops2",
+    "pointops2_cuda",
+    "pointops2.pointops",
+    "ocnn",
+}
+_SUBMODULES = [
+    ".sparse_unet",
+    ".point_transformer",
+    ".point_transformer_v2",
+    ".point_transformer_v3",
+    ".stratified_transformer",
+    ".spvcnn",
+    ".octformer",
+    ".oacnns",
+    ".context_aware_classifier",
+    ".point_group",
+    ".sgiformer",
+    ".masked_scene_contrast",
+    ".point_prompt_training",
+    ".sonata",
+]
 
-# Semantic Segmentation
-from .context_aware_classifier import *
 
-# Instance Segmentation
-from .point_group import *
-from .sgiformer import *
+def _register_exports(names: list[str]) -> None:
+    for name in names:
+        if name not in _EXPORTED:
+            __all__.append(name)
+            _EXPORTED.add(name)
 
-# Pretraining
-from .masked_scene_contrast import *
-from .point_prompt_training import *
-from .sonata import *
+
+def _safe_import(module_name: str) -> None:
+    try:
+        module = import_module(module_name, package=__name__)
+    except ModuleNotFoundError as exc:
+        missing = exc.name or ""
+        if missing in _OPTIONAL_DEPENDENCIES:
+            warnings.warn(
+                f"Skipping '{module_name}' because optional dependency '{missing}' is unavailable.",
+                ImportWarning,
+            )
+            return
+        raise
+
+    exports = getattr(module, "__all__", None)
+    if exports is None:
+        exports = [name for name in dir(module) if not name.startswith("_")]
+    for attr in exports:
+        globals()[attr] = getattr(module, attr)
+    _register_exports(list(exports))
+
+
+for _module_name in _SUBMODULES:
+    _safe_import(_module_name)
+
+
+del _module_name
+del _register_exports
+del _safe_import
+del _EXPORTED
+del _OPTIONAL_DEPENDENCIES
+del _SUBMODULES

--- a/pointcept/models/modules.py
+++ b/pointcept/models/modules.py
@@ -9,7 +9,36 @@ except ImportError:
 
 from collections import OrderedDict
 from pointcept.models.utils.structure import Point
-from pointcept.engines.hooks import HookBase
+
+try:
+    from pointcept.engines.hooks import HookBase
+except ModuleNotFoundError as exc:
+    if exc.name == "wandb":
+        class HookBase:  # type: ignore[override]
+            """Minimal fallback when Weights & Biases is unavailable."""
+
+            trainer = None  # type: ignore[assignment]
+
+            def before_train(self):
+                pass
+
+            def before_epoch(self):
+                pass
+
+            def before_step(self):
+                pass
+
+            def after_step(self):
+                pass
+
+            def after_epoch(self):
+                pass
+
+            def after_train(self):
+                pass
+
+    else:
+        raise
 
 
 def is_ocnn_module(module):

--- a/simple_ptv3/README.md
+++ b/simple_ptv3/README.md
@@ -1,0 +1,67 @@
+# Simple PointTransformer V3 for S3DIS
+
+This folder contains a lightweight training script that focuses on semantic
+segmentation on S3DIS with a Sonata-pretrained PointTransformer V3 backbone.
+Only two probing setups are provided:
+
+- **Linear probing** – freeze the entire backbone and train a linear classifier.
+- **Decoder probing** – freeze the encoder (stem + downsampling blocks) and train
+the decoder together with the segmentation head.
+
+A regular fine-tuning mode is also available for completeness.
+
+## Requirements
+
+The implementation reuses Pointcept modules, therefore install the same
+dependencies as the original project. In addition you need the preprocessed
+S3DIS rooms (see the main README for preprocessing instructions) and a Sonata
+pretrained checkpoint. The official weights published with the
+[`facebookresearch/sonata`](https://github.com/facebookresearch/sonata) repo can
+be downloaded from Hugging Face; the script reads the configuration embedded in
+those checkpoints so that the backbone is instantiated with the exact training
+hyper-parameters.
+
+## Quick start
+
+```bash
+# Linear probing
+python -m simple_ptv3.train \
+    --data-root data/s3dis \
+    --pretrained /path/to/sonata_backbone.pth \
+    --probe-mode linear \
+    --batch-size 4 \
+    --epochs 100
+
+# Decoder probing
+python -m simple_ptv3.train \
+    --data-root data/s3dis \
+    --pretrained /path/to/sonata_backbone.pth \
+    --probe-mode decoder \
+    --batch-size 4 \
+    --epochs 100
+```
+
+By default the script trains on Areas 1/2/3/4/6 and validates on Area 5. The
+number of points sampled per room, the grid size used for serialization and the
+optimizer settings can be customised through command line flags (check
+`python -m simple_ptv3.train --help`).
+
+To evaluate a pretrained checkpoint without further training run:
+
+```bash
+python -m simple_ptv3.train --data-root data/s3dis --pretrained checkpoint.pth --eval-only
+
+```
+
+FlashAttention kernels are disabled by default so that the code can run without
+the optional dependency. If your environment provides FlashAttention you can
+turn them back on with `--enable-flash`.
+
+## Outputs
+
+When `--save-best` is enabled the best performing model w.r.t validation mIoU is
+stored under the directory specified by `--output-dir`. Otherwise the final
+checkpoint after the last epoch is written.
+
+Validation metrics (loss, mIoU, overall accuracy, per-class IoU) are printed at
+the end of every epoch.

--- a/simple_ptv3/__init__.py
+++ b/simple_ptv3/__init__.py
@@ -1,0 +1,18 @@
+"""Simplified PointTransformer V3 training utilities."""
+
+from .dataset import S3DISSimpleDataset, simple_collate_fn
+from .model import (
+    BackboneConfig,
+    SimplePointTransformerV3Segmentor,
+    load_sonata_checkpoint,
+)
+from .metrics import SegmentationMetric
+
+__all__ = [
+    "S3DISSimpleDataset",
+    "simple_collate_fn",
+    "BackboneConfig",
+    "SimplePointTransformerV3Segmentor",
+    "load_sonata_checkpoint",
+    "SegmentationMetric",
+]

--- a/simple_ptv3/dataset.py
+++ b/simple_ptv3/dataset.py
@@ -1,0 +1,187 @@
+"""Lightweight S3DIS dataset loader for PointTransformer V3."""
+
+from __future__ import annotations
+
+import glob
+import os
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass
+class DatasetConfig:
+    """Configuration options for :class:`S3DISSimpleDataset`."""
+
+    data_root: str
+    areas: Sequence[str]
+    num_points: int | None = 65536
+    grid_size: float = 0.02
+    augment: bool = False
+    training: bool = True
+
+
+class S3DISSimpleDataset(Dataset):
+    """Minimal S3DIS loader that returns tensors ready for PointTransformer V3.
+
+    The class expects the preprocessed S3DIS directory that ships with Pointcept,
+    i.e. each area contains folders for each room and every room holds
+    ``coord.npy``, ``color.npy``, ``normal.npy`` and ``segment.npy`` files.
+    """
+
+    def __init__(self, config: DatasetConfig | None = None, **kwargs):
+        if config is None:
+            config = DatasetConfig(**kwargs)  # type: ignore[arg-type]
+        if isinstance(config.areas, str):  # pragma: no cover - convenience branch
+            areas: Sequence[str] = (config.areas,)
+        else:
+            areas = tuple(config.areas)
+        self.config = config
+        self.data_root = os.path.expanduser(config.data_root)
+        self.areas = areas
+        self.num_points = config.num_points
+        self.grid_size = config.grid_size
+        self.augment = config.augment and config.training
+        self.training = config.training
+
+        self.files: List[str] = []
+        for area in self.areas:
+            pattern = os.path.join(self.data_root, area, "*")
+            rooms = sorted(glob.glob(pattern))
+            self.files.extend(rooms)
+        if not self.files:
+            raise FileNotFoundError(
+                f"No S3DIS rooms found under '{self.data_root}' for areas {self.areas}."
+            )
+
+    def __len__(self) -> int:
+        return len(self.files)
+
+    def __getitem__(self, index: int) -> dict:
+        path = self.files[index]
+        coord = self._load_numpy(path, "coord")
+        color = self._load_numpy(path, "color", fallback=np.zeros_like(coord))
+        normal = self._load_numpy(path, "normal", fallback=np.zeros_like(coord))
+        label = self._load_numpy(path, "segment").astype(np.int64)
+
+        coord = coord.astype(np.float32)
+        coord -= coord.mean(axis=0, keepdims=True)
+        color = (color.astype(np.float32)) / 255.0
+        normal = normal.astype(np.float32)
+
+        coord, color, normal, label = self._maybe_sample(coord, color, normal, label)
+
+        if self.augment:
+            coord, normal, color = self._augment(coord, normal, color)
+
+        feat = np.concatenate([coord, color, normal], axis=1)
+
+        # Grid coordinates are required by PointTransformer for serialization.
+        min_coord = coord.min(axis=0, keepdims=True)
+        grid_coord = np.floor((coord - min_coord) / self.grid_size).astype(np.int32)
+
+        return {
+            "coord": torch.from_numpy(coord),
+            "grid_coord": torch.from_numpy(grid_coord),
+            "feat": torch.from_numpy(feat),
+            "segment": torch.from_numpy(label.astype(np.int64)),
+            "name": os.path.basename(path),
+        }
+
+    def _load_numpy(
+        self,
+        directory: str,
+        name: str,
+        fallback: np.ndarray | None = None,
+    ) -> np.ndarray:
+        file_path = os.path.join(directory, f"{name}.npy")
+        if os.path.isfile(file_path):
+            return np.load(file_path)
+        if fallback is None:
+            raise FileNotFoundError(f"Expected file '{file_path}' not found.")
+        return fallback.copy()
+
+    def _maybe_sample(
+        self,
+        coord: np.ndarray,
+        color: np.ndarray,
+        normal: np.ndarray,
+        label: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        if self.num_points is None:
+            return coord, color, normal, label
+        total = coord.shape[0]
+        if total == self.num_points:
+            return coord, color, normal, label
+        if self.training:
+            choice = np.random.choice(total, self.num_points, replace=total < self.num_points)
+        else:
+            if total >= self.num_points:
+                choice = np.arange(self.num_points)
+            else:
+                repeat = self.num_points - total
+                extra = np.tile(np.arange(total), int(np.ceil(repeat / total)))[:repeat]
+                choice = np.concatenate([np.arange(total), extra])
+        return coord[choice], color[choice], normal[choice], label[choice]
+
+    def _augment(
+        self,
+        coord: np.ndarray,
+        normal: np.ndarray,
+        color: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        theta = np.random.uniform(0.0, 2.0 * np.pi)
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        rot_z = np.array(
+            [[cos_theta, -sin_theta, 0.0], [sin_theta, cos_theta, 0.0], [0.0, 0.0, 1.0]],
+            dtype=np.float32,
+        )
+        coord = coord @ rot_z.T
+        normal = normal @ rot_z.T
+
+        scale = np.random.uniform(0.95, 1.05)
+        coord *= scale
+
+        jitter = np.clip(np.random.normal(0.0, 0.01, size=coord.shape), -0.05, 0.05).astype(
+            np.float32
+        )
+        coord += jitter
+
+        color = np.clip(color + np.random.normal(0.0, 0.02, color.shape), 0.0, 1.0)
+        return coord, normal, color
+
+
+def simple_collate_fn(batch: Iterable[dict]) -> dict:
+    """Merge a list of dataset items into a batch for PointTransformer."""
+
+    coords: List[torch.Tensor] = []
+    grid_coords: List[torch.Tensor] = []
+    feats: List[torch.Tensor] = []
+    labels: List[torch.Tensor] = []
+    offsets: List[int] = []
+    names: List[str] = []
+
+    total_points = 0
+    for item in batch:
+        num_points = item["coord"].shape[0]
+        total_points += num_points
+        offsets.append(total_points)
+        coords.append(item["coord"].float())
+        grid_coords.append(item["grid_coord"].int())
+        feats.append(item["feat"].float())
+        labels.append(item["segment"].long())
+        names.append(item.get("name", ""))
+
+    merged = {
+        "coord": torch.cat(coords, dim=0),
+        "grid_coord": torch.cat(grid_coords, dim=0),
+        "feat": torch.cat(feats, dim=0),
+        "segment": torch.cat(labels, dim=0),
+        "offset": torch.tensor(offsets, dtype=torch.int32),
+        "name": names,
+    }
+    return merged

--- a/simple_ptv3/metrics.py
+++ b/simple_ptv3/metrics.py
@@ -1,0 +1,44 @@
+"""Utility metrics for semantic segmentation."""
+
+from __future__ import annotations
+
+import torch
+
+
+class SegmentationMetric:
+    """Track segmentation accuracy and mean IoU across iterations."""
+
+    def __init__(self, num_classes: int, ignore_index: int = -1) -> None:
+        self.num_classes = num_classes
+        self.ignore_index = ignore_index
+        self.reset()
+
+    def reset(self) -> None:
+        self.confusion = torch.zeros((self.num_classes, self.num_classes), dtype=torch.int64)
+
+    @torch.no_grad()
+    def add_batch(self, prediction: torch.Tensor, target: torch.Tensor) -> None:
+        if prediction.shape != target.shape:
+            raise ValueError("Prediction and target must share the same shape.")
+        mask = target != self.ignore_index
+        if not torch.any(mask):
+            return
+        pred = prediction[mask].view(-1)
+        gt = target[mask].view(-1)
+        index = gt * self.num_classes + pred
+        conf = torch.bincount(index, minlength=self.num_classes ** 2)
+        self.confusion += conf.view(self.num_classes, self.num_classes).cpu()
+
+    def compute(self) -> dict:
+        conf = self.confusion.float()
+        tp = conf.diag()
+        pos = conf.sum(dim=1)
+        res = conf.sum(dim=0)
+        denom = pos + res - tp
+        iou = torch.where(denom > 0, tp / denom.clamp(min=1e-6), torch.zeros_like(tp))
+        overall_acc = tp.sum() / conf.sum().clamp(min=1.0)
+        return {
+            "mIoU": iou.mean().item(),
+            "per_class_iou": iou.tolist(),
+            "overall_acc": overall_acc.item(),
+        }

--- a/simple_ptv3/model.py
+++ b/simple_ptv3/model.py
@@ -1,0 +1,222 @@
+"""Simplified PointTransformer V3 segmentor."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, fields, replace
+from typing import Dict, Tuple
+
+import torch
+import torch.nn as nn
+
+from pointcept.models.point_transformer_v3.point_transformer_v3m2_sonata import (
+    PointTransformerV3,
+)
+from pointcept.models.utils.structure import Point
+
+
+def _ensure_tuple(value):
+    if isinstance(value, tuple):
+        return value
+    if isinstance(value, list):
+        return tuple(value)
+    return value
+
+
+@dataclass
+class BackboneConfig:
+    """Configuration for the :class:`PointTransformerV3` backbone."""
+
+    in_channels: int = 9
+    order: Tuple[str, ...] = ("z", "z-trans", "hilbert", "hilbert-trans")
+    stride: Tuple[int, ...] = (2, 2, 2, 2)
+    enc_depths: Tuple[int, ...] = (3, 3, 3, 12, 3)
+    enc_channels: Tuple[int, ...] = (48, 96, 192, 384, 512)
+    enc_num_head: Tuple[int, ...] = (3, 6, 12, 24, 32)
+    enc_patch_size: Tuple[int, ...] = (1024, 1024, 1024, 1024, 1024)
+    dec_depths: Tuple[int, ...] = (2, 2, 2, 2)
+    dec_channels: Tuple[int, ...] = (64, 96, 192, 384)
+    dec_num_head: Tuple[int, ...] = (4, 6, 12, 24)
+    dec_patch_size: Tuple[int, ...] = (1024, 1024, 1024, 1024)
+    mlp_ratio: int = 4
+    qkv_bias: bool = True
+    qk_scale: float | None = None
+    attn_drop: float = 0.0
+    proj_drop: float = 0.0
+    drop_path: float = 0.3
+    layer_scale: float | None = None
+    shuffle_orders: bool = True
+    pre_norm: bool = True
+    enable_rpe: bool = False
+    enable_flash: bool = False
+    upcast_attention: bool = False
+    upcast_softmax: bool = False
+    traceable: bool = False
+    mask_token: bool = False
+    enc_mode: bool = False
+    freeze_encoder: bool = False
+
+    @classmethod
+    def from_dict(cls, config: Mapping[str, object]) -> "BackboneConfig":
+        """Build a configuration from a checkpoint dictionary."""
+
+        field_names = {field.name for field in fields(cls)}
+        kwargs = {}
+        for key in field_names:
+            if key in config:
+                value = config[key]
+                value = _ensure_tuple(value)
+                kwargs[key] = value
+        return cls(**kwargs)
+
+    def to_kwargs(self) -> dict:
+        """Convert the dataclass to a dict compatible with ``PointTransformerV3``."""
+
+        kwargs = {}
+        for field in fields(self):
+            value = getattr(self, field.name)
+            kwargs[field.name] = _ensure_tuple(value)
+        return kwargs
+
+    def for_probe_mode(self, probe_mode: str) -> "BackboneConfig":
+        """Return a copy with ``enc_mode``/``freeze_encoder`` adapted to a probe."""
+
+        config = replace(self)
+        if probe_mode == "linear":
+            config.enc_mode = True
+            config.freeze_encoder = False
+        elif probe_mode == "decoder":
+            config.enc_mode = False
+            config.freeze_encoder = True
+        else:
+            config.enc_mode = False
+            config.freeze_encoder = False
+        return config
+
+
+def load_sonata_checkpoint(
+    checkpoint_path: str, map_location: str | torch.device = "cpu"
+) -> tuple[dict | None, Mapping[str, torch.Tensor]]:
+    """Load a Sonata checkpoint and extract its config and state dict."""
+
+    try:
+        checkpoint = torch.load(
+            checkpoint_path, map_location=map_location, weights_only=True
+        )
+    except TypeError:  # ``weights_only`` is only available in newer PyTorch versions.
+        checkpoint = torch.load(checkpoint_path, map_location=map_location)
+
+    config = checkpoint.get("config") if isinstance(checkpoint, Mapping) else None
+    state = None
+    if isinstance(checkpoint, Mapping):
+        if "state_dict" in checkpoint and isinstance(checkpoint["state_dict"], Mapping):
+            state = checkpoint["state_dict"]
+        elif "model" in checkpoint and isinstance(checkpoint["model"], Mapping):
+            state = checkpoint["model"]
+    if state is None:
+        state = checkpoint if isinstance(checkpoint, Mapping) else {}
+    if "state_dict" in state and isinstance(state["state_dict"], Mapping):
+        state = state["state_dict"]
+    return config, state
+
+
+class SimplePointTransformerV3Segmentor(nn.Module):
+    """Minimal wrapper around :class:`PointTransformerV3` for segmentation."""
+
+    def __init__(
+        self,
+        num_classes: int = 13,
+        probe_mode: str = "linear",
+        backbone_config: BackboneConfig | None = None,
+    ) -> None:
+        super().__init__()
+        if backbone_config is None:
+            backbone_config = BackboneConfig()
+        self.probe_mode = probe_mode
+        self.backbone_config = backbone_config.for_probe_mode(probe_mode)
+        config_dict = self.backbone_config.to_kwargs()
+        self.backbone = PointTransformerV3(**config_dict)
+        if self.backbone_config.enc_mode:
+            self.backbone_out_channels = sum(self.backbone_config.enc_channels)
+        else:
+            self.backbone_out_channels = self.backbone_config.dec_channels[0]
+        self.seg_head = nn.Linear(self.backbone_out_channels, num_classes)
+        if probe_mode == "linear":
+            for param in self.backbone.parameters():
+                param.requires_grad = False
+
+    def forward(self, inputs: Dict[str, torch.Tensor]) -> torch.Tensor:
+        point = Point(inputs)
+        if self.probe_mode == "linear":
+            with torch.no_grad():
+                point = self.backbone(point)
+        else:
+            point = self.backbone(point)
+        feat = self._gather_backbone_features(point)
+        return self.seg_head(feat)
+
+    def _gather_backbone_features(self, point: Point | torch.Tensor) -> torch.Tensor:
+        if isinstance(point, Point):
+            while "pooling_parent" in point.keys():
+                parent = point.pop("pooling_parent")
+                inverse = point.pop("pooling_inverse")
+                parent.feat = torch.cat([parent.feat, point.feat[inverse]], dim=-1)
+                point = parent
+            return point.feat
+        return point
+
+    def train(self, mode: bool = True) -> "SimplePointTransformerV3Segmentor":
+        super().train(mode)
+        if self.probe_mode == "linear":
+            self.backbone.eval()
+        elif self.probe_mode == "decoder":
+            if hasattr(self.backbone, "embedding"):
+                self.backbone.embedding.eval()
+            if hasattr(self.backbone, "enc"):
+                self.backbone.enc.eval()
+        return self
+
+    def get_trainable_parameters(self) -> Iterable[torch.nn.Parameter]:
+        for param in self.parameters():
+            if param.requires_grad:
+                yield param
+
+    def load_pretrained(self, checkpoint_path: str, strict: bool = False) -> Tuple[list[str], list[str]]:
+        _, state_dict = load_sonata_checkpoint(checkpoint_path)
+        return self.load_pretrained_state(state_dict, strict=strict)
+
+    def load_pretrained_state(
+        self, state_dict: Mapping[str, torch.Tensor], strict: bool = False
+    ) -> Tuple[list[str], list[str]]:
+        """Load a pre-extracted state dict into the backbone."""
+
+        filtered = self._filter_backbone_state(state_dict)
+        missing, unexpected = self.backbone.load_state_dict(filtered, strict=strict)
+        return list(missing), list(unexpected)
+
+    def _filter_backbone_state(
+        self, state_dict: Mapping[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        target_keys = set(self.backbone.state_dict().keys())
+        filtered: dict[str, torch.Tensor] = {}
+        for key, value in state_dict.items():
+            if not isinstance(value, torch.Tensor):
+                continue
+            if "teacher." in key:
+                continue
+            name = key
+            for prefix in (
+                "module.student.backbone.",
+                "student.backbone.",
+                "module.backbone.",
+                "model.backbone.",
+                "backbone.",
+                "module.",
+                "model.",
+                "student.",
+            ):
+                if name.startswith(prefix):
+                    name = name[len(prefix) :]
+            if name in target_keys:
+                filtered[name] = value
+        return filtered

--- a/simple_ptv3/train.py
+++ b/simple_ptv3/train.py
@@ -1,0 +1,244 @@
+"""Command line training interface for the simplified PTv3 segmentor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+
+from .dataset import DatasetConfig, S3DISSimpleDataset, simple_collate_fn
+from .metrics import SegmentationMetric
+from .model import (
+    BackboneConfig,
+    SimplePointTransformerV3Segmentor,
+    load_sonata_checkpoint,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-root", type=str, required=True, help="Path to processed S3DIS")
+    parser.add_argument(
+        "--train-areas",
+        nargs="+",
+        default=["Area_1", "Area_2", "Area_3", "Area_4", "Area_6"],
+        help="Training splits (directories) to use.",
+    )
+    parser.add_argument(
+        "--val-area", type=str, default="Area_5", help="Validation split directory"
+    )
+    parser.add_argument("--num-points", type=int, default=65536, help="Points per room")
+    parser.add_argument("--grid-size", type=float, default=0.02, help="Voxel size for grid coords")
+    parser.add_argument(
+        "--probe-mode",
+        choices=["linear", "decoder", "finetune"],
+        default="linear",
+        help="Training regime.",
+    )
+    parser.add_argument("--pretrained", type=str, default="", help="Path to Sonata weights")
+    parser.add_argument("--epochs", type=int, default=300, help="Training epochs")
+    parser.add_argument("--batch-size", type=int, default=2, help="Batch size")
+    parser.add_argument("--lr", type=float, default=2e-3, help="AdamW learning rate")
+    parser.add_argument("--weight-decay", type=float, default=2e-2, help="Weight decay")
+    parser.add_argument("--num-workers", type=int, default=4, help="Data loader workers")
+    parser.add_argument("--amp", action="store_true", help="Use automatic mixed precision")
+    parser.add_argument(
+        "--enable-flash",
+        action="store_true",
+        help="Enable FlashAttention kernels if the environment supports them.",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument("--device", type=str, default="cuda", help="Compute device")
+    parser.add_argument("--output-dir", type=str, default="runs/simple_ptv3", help="Log directory")
+    parser.add_argument("--save-best", action="store_true", help="Persist best checkpoint")
+    parser.add_argument("--eval-only", action="store_true", help="Skip training and evaluate")
+    parser.add_argument(
+        "--log-interval", type=int, default=10, help="Steps between progress messages"
+    )
+    return parser.parse_args()
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def build_dataloaders(args: argparse.Namespace) -> tuple[DataLoader, DataLoader]:
+    train_dataset = S3DISSimpleDataset(
+        DatasetConfig(
+            data_root=args.data_root,
+            areas=args.train_areas,
+            num_points=args.num_points,
+            grid_size=args.grid_size,
+            augment=True,
+            training=True,
+        )
+    )
+    val_dataset = S3DISSimpleDataset(
+        DatasetConfig(
+            data_root=args.data_root,
+            areas=[args.val_area],
+            num_points=args.num_points,
+            grid_size=args.grid_size,
+            augment=False,
+            training=False,
+        )
+    )
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=True,
+        collate_fn=simple_collate_fn,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=True,
+        collate_fn=simple_collate_fn,
+    )
+    return train_loader, val_loader
+
+
+def build_model(args: argparse.Namespace) -> SimplePointTransformerV3Segmentor:
+    checkpoint_cfg = None
+    checkpoint_state = None
+    if args.pretrained:
+        cfg_dict, checkpoint_state = load_sonata_checkpoint(args.pretrained)
+        if cfg_dict is not None:
+            checkpoint_cfg = BackboneConfig.from_dict(cfg_dict)
+    backbone_cfg = checkpoint_cfg or BackboneConfig()
+    backbone_cfg.enable_flash = bool(args.enable_flash)
+    model = SimplePointTransformerV3Segmentor(
+        num_classes=13,
+        probe_mode=args.probe_mode,
+        backbone_config=backbone_cfg,
+    )
+    if checkpoint_state:
+        missing, unexpected = model.load_pretrained_state(checkpoint_state)
+        print(f"Loaded pretrained backbone from {args.pretrained}")
+        if missing:
+            print(f"Missing keys: {missing}")
+        if unexpected:
+            print(f"Unexpected keys: {unexpected}")
+    elif args.pretrained:
+        missing, unexpected = model.load_pretrained(args.pretrained)
+        print(f"Loaded pretrained backbone from {args.pretrained}")
+        if missing:
+            print(f"Missing keys: {missing}")
+        if unexpected:
+            print(f"Unexpected keys: {unexpected}")
+    return model
+
+
+def prepare_batch(batch: Dict[str, torch.Tensor], device: torch.device) -> Dict[str, torch.Tensor]:
+    prepared = {}
+    for key, value in batch.items():
+        if isinstance(value, torch.Tensor):
+            prepared[key] = value.to(device)
+    return prepared
+
+
+def train_one_epoch(
+    model: SimplePointTransformerV3Segmentor,
+    loader: DataLoader,
+    optimizer: torch.optim.Optimizer,
+    scaler: torch.cuda.amp.GradScaler,
+    device: torch.device,
+    epoch: int,
+    log_interval: int,
+) -> float:
+    model.train(True)
+    running_loss = 0.0
+    for step, batch in enumerate(loader, start=1):
+        prepared = prepare_batch(batch, device)
+        optimizer.zero_grad(set_to_none=True)
+        with torch.cuda.amp.autocast(enabled=scaler.is_enabled()):
+            logits = model(prepared)
+            loss = F.cross_entropy(logits, prepared["segment"], ignore_index=-1)
+        scaler.scale(loss).backward()
+        scaler.step(optimizer)
+        scaler.update()
+        running_loss += loss.item()
+        if step % log_interval == 0:
+            print(f"Epoch {epoch:03d} | Step {step:04d}/{len(loader):04d} | Loss {loss.item():.4f}")
+    return running_loss / max(len(loader), 1)
+
+
+def evaluate(
+    model: SimplePointTransformerV3Segmentor,
+    loader: DataLoader,
+    device: torch.device,
+) -> dict:
+    model.eval()
+    metric = SegmentationMetric(num_classes=13, ignore_index=-1)
+    total_loss = 0.0
+    with torch.no_grad():
+        for batch in loader:
+            prepared = prepare_batch(batch, device)
+            logits = model(prepared)
+            loss = F.cross_entropy(logits, prepared["segment"], ignore_index=-1)
+            preds = logits.argmax(dim=1)
+            metric.add_batch(preds.cpu(), prepared["segment"].cpu())
+            total_loss += loss.item()
+    metrics = metric.compute()
+    metrics["loss"] = total_loss / max(len(loader), 1)
+    return metrics
+
+
+def save_checkpoint(model: SimplePointTransformerV3Segmentor, output_dir: Path, epoch: int) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"checkpoint-epoch{epoch:03d}.pth"
+    torch.save({"model": model.state_dict(), "epoch": epoch}, path)
+    print(f"Checkpoint saved to {path}")
+
+
+def main() -> None:
+    args = parse_args()
+    set_seed(args.seed)
+    device = torch.device(args.device if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+    train_loader, val_loader = build_dataloaders(args)
+    model = build_model(args).to(device)
+    scaler = torch.cuda.amp.GradScaler(enabled=args.amp)
+    optimizer = torch.optim.AdamW(
+        model.get_trainable_parameters(), lr=args.lr, weight_decay=args.weight_decay
+    )
+
+    output_dir = Path(args.output_dir)
+    best_miou = -1.0
+
+    if args.eval_only:
+        metrics = evaluate(model, val_loader, device)
+        print(json.dumps(metrics, indent=2))
+        return
+
+    for epoch in range(1, args.epochs + 1):
+        train_loss = train_one_epoch(model, train_loader, optimizer, scaler, device, epoch, args.log_interval)
+        metrics = evaluate(model, val_loader, device)
+        print(
+            f"Epoch {epoch:03d} | Train Loss {train_loss:.4f} | Val Loss {metrics['loss']:.4f} | mIoU {metrics['mIoU']:.3f}"
+        )
+        if args.save_best and metrics["mIoU"] > best_miou:
+            best_miou = metrics["mIoU"]
+            save_checkpoint(model, output_dir, epoch)
+
+    if not args.save_best:
+        save_checkpoint(model, output_dir, args.epochs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the hard wandb dependency in `pointcept.models.modules` with a no-op HookBase stub so PointTransformer imports succeed without Weights & Biases
- lazily import model subpackages and skip ones that require optional libraries such as pointops, keeping Sonata/PTv3 components available in minimal environments

## Testing
- python -m compileall simple_ptv3 pointcept/models/__init__.py pointcept/models/modules.py

------
https://chatgpt.com/codex/tasks/task_e_68cbbdfa02b0832fad907c2904e56605